### PR TITLE
Allowing for the same flag to be set multiple times when using a conf…

### DIFF
--- a/extras.go
+++ b/extras.go
@@ -114,6 +114,14 @@ func (f *FlagSet) ParseFile(path string) error {
 	}
 	defer fp.Close()
 
+	// Allow multiple values for the same flag while still allowing arguments to take precedence.
+	// We create a temporary map that stores if an arg has already been set but won't be modified
+	// when we set args while parsing the file.
+	hasArg := make(map[string]bool)
+	for name := range f.actual {
+		hasArg[name] = true
+	}
+
 	scanner := bufio.NewScanner(fp)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -144,7 +152,7 @@ func (f *FlagSet) ParseFile(path string) error {
 		}
 
 		// Ignore flag when already set; arguments have precedence over file
-		if f.actual[name] != nil {
+		if hasArg[name] {
 			continue
 		}
 

--- a/extras_test.go
+++ b/extras_test.go
@@ -6,6 +6,7 @@ package flag_test
 
 import (
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -71,6 +72,17 @@ func TestParseEnv(t *testing.T) {
 	}
 }
 
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	return strings.Join(*i, " ")
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 // Test parsing a configuration file
 func TestParseFile(t *testing.T) {
 
@@ -85,6 +97,9 @@ func TestParseFile(t *testing.T) {
 	stringFlag := f.String("string", "0", "string value")
 	float64Flag := f.Float64("float64", 0, "float64 value")
 	durationFlag := f.Duration("duration", 5*time.Second, "time.Duration value")
+
+	multi := new(arrayFlags)
+	f.Var(multi, "multi", "Array flags value")
 
 	err := f.ParseFile("./testdata/test.conf")
 	if err != nil {
@@ -117,6 +132,10 @@ func TestParseFile(t *testing.T) {
 	if *durationFlag != 2*time.Minute {
 		t.Error("duration flag should be 2m, is ", *durationFlag)
 	}
+	if multi.String() != "hello world" {
+		t.Error("value of array flags should be hello world, is ", multi.String())
+	}
+
 }
 
 func TestParseFileUnknownFlag(t *testing.T) {
@@ -138,6 +157,9 @@ func TestDefaultConfigFlagname(t *testing.T) {
 	stringFlag := f.String("string", "0", "string value")
 	f.Float64("float64", 0, "float64 value")
 	f.Duration("duration", 5*time.Second, "time.Duration value")
+
+	multi := new(arrayFlags)
+	f.Var(multi, "multi", "Array flags value")
 
 	f.String(DefaultConfigFlagname, "./testdata/test.conf", "config path")
 

--- a/testdata/test.conf
+++ b/testdata/test.conf
@@ -9,3 +9,5 @@ uint64 25
 string hello
 float64 2718e28
 duration 2m
+multi hello
+multi world


### PR DESCRIPTION
…iguration file

I'm hoping you'll consider merging this pull request that allows for multiple values for the same flag when using a configuration file. This is already something the module supports when using command line flags.

Flag example:

`-arg hello -arg world`

Config example:

~~~
arg hello
arg world
~~~

Thanks!